### PR TITLE
Updating Sender Constructor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ sender.setAPIKey('key');
 
 ```javascript
 var sender = new gcm.Sender({
-	key: 'my_api_key'
+	apiKey: 'my_api_key'
 });
 ```
 


### PR DESCRIPTION
The documentation showed using:
{ key:'my-api-key'} But Sender expects: { apiKey:'my-api-key'}
